### PR TITLE
:bug: fix disposal scenarios and improve exception handling

### DIFF
--- a/src/Spillgebees.Blazor.RichTextEditor.Assets/src/interfaces/spillgebees.ts
+++ b/src/Spillgebees.Blazor.RichTextEditor.Assets/src/interfaces/spillgebees.ts
@@ -27,9 +27,8 @@ interface EditorFunctions {
     setSelection(quillReference: QuillReference, range: RangeStatic): void;
     getText(quillReference: QuillReference): string;
     insertImage(quillReference: QuillReference, imageUrl: string): void;
-    disposeEditor(quillReference: QuillReference): Promise<void>;
+    disposeEditor(quillReference: QuillReference): void;
     registerQuillEventCallback(quillReference: QuillReference, eventName: "text-change" | "selection-change", callback: (...args : any[]) => Promise<QuillEvent>): void;
-    deregisterQuillEventCallback(quillReference: QuillReference, eventName: "text-change" | "selection-change", callback: (...args : any[]) => Promise<QuillEvent>): void;
 }
 
 export { Spillgebees, EditorFunctions };

--- a/src/Spillgebees.Blazor.RichTextEditor.Assets/tsconfig.json
+++ b/src/Spillgebees.Blazor.RichTextEditor.Assets/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": [
       "ESNext",
       "DOM"

--- a/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Server/Program.cs
+++ b/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Server/Program.cs
@@ -1,6 +1,11 @@
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
-builder.Services.AddServerSideBlazor();
+builder.Services
+    .AddServerSideBlazor()
+    .AddCircuitOptions(options =>
+    {
+        options.DetailedErrors = true;
+    });
 builder.Services.AddSignalR(e => {
     e.MaximumReceiveMessageSize = 102400000;
 });

--- a/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.WebApp/wwwroot/app.css
+++ b/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.WebApp/wwwroot/app.css
@@ -1,4 +1,4 @@
-@import "./_content/Spillgebees.Blazor.RichTextEditor/Spillgebees.Blazor.RichTextEditor.lib.module.css";
+@import "_content/Spillgebees.Blazor.RichTextEditor/Spillgebees.Blazor.RichTextEditor.lib.module.css";
 
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/src/Spillgebees.Blazor.RichTextEditor/Components/RichTextEditor.razor.cs
+++ b/src/Spillgebees.Blazor.RichTextEditor/Components/RichTextEditor.razor.cs
@@ -6,19 +6,16 @@ namespace Spillgebees.Blazor.RichTextEditor.Components;
 
 public partial class RichTextEditor : BaseRichTextEditor
 {
-    [JSInvokable]
-    public override async Task OnContentChangedAsync(TextChangeEvent args)
+    protected override async Task OnContentChangedAction(TextChangeEvent args)
     {
-        await base.OnContentChangedAsync(args);
         await UpdateContentAsync();
         await UpdateTextAsync();
+        await base.OnContentChangedAction(args);
     }
 
-    [JSInvokable]
-    public override async Task OnSelectionChangedAsync(SelectionChangeEvent args)
+    protected override async Task OnSelectionChangedAction(SelectionChangeEvent args)
     {
-        await base.OnSelectionChangedAsync(args);
-        InternalSelection = args.NewRange;
-        await SelectionChanged.InvokeAsync(InternalSelection);
+        await base.OnSelectionChangedAction(args);
+        await UpdateSelectionAsync();
     }
 }


### PR DESCRIPTION
Fixes: #25

- added safer ways to deal with missing references on the `.ts` side of things
- added a `TaskCompletionSource` ensuring the initialization process is done before `DisposeAsync` can do its thing