### PR TITLE
✨ add `ToolbarOptions.None` helper & `ToolbarOptions.HideToolbar` flag

### DIFF
--- a/src/Spillgebees.Blazor.RichTextEditor.Assets/src/styles.css
+++ b/src/Spillgebees.Blazor.RichTextEditor.Assets/src/styles.css
@@ -16,7 +16,7 @@
     border-top: none;
 }
 
-.ql-toolbar.ql-snow.rich-text-editor-toolbar-container-hidden + .ql-container.ql-snow.ql-disabled.rich-text-editor-editor-container {
+.ql-toolbar.ql-snow.rich-text-editor-toolbar-container-hidden + .ql-container.ql-snow.rich-text-editor-editor-container {
     border-top: 1px solid #ccc;
 }
 

--- a/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Shared/Examples/NoToolbarExample.razor
+++ b/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Shared/Examples/NoToolbarExample.razor
@@ -1,0 +1,26 @@
+﻿<div>
+    <h3>Setting the <code class="hljs">ToolbarOptions</code> parameter to <code class="hljs">ToolbarOptions.None</code>,
+        or changing the <code class="hljs">ToolbarOptions.HideToolbar</code> value to <code class="hljs">true</code>
+        completely hides the toolbar.</h3>
+    <CodeSnippet Code="@Code">
+        <Component>
+            <CodeSnippet Code="@_content"
+                         CodeFormat="CodeFormat.Html"
+                         Summary="Show HTML">
+                <Component>
+                    <RichTextEditor @bind-Content="@_content"
+                                    ToolbarOptions="@ToolbarOptions.None" />
+                </Component>
+            </CodeSnippet>
+        </Component>
+    </CodeSnippet>
+</div>
+
+
+@code {
+    private const string Code =
+@"<RichTextEditor @bind-Content=""@_content""
+                ToolbarOptions=""@ToolbarOptions.None"" />";
+
+    private string _content = "<b>Hello from an editor without toolbar! \ud83d\udc4b</b>";
+}

--- a/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Shared/Pages/RichTextEditorExamplesPageContent.razor
+++ b/src/Spillgebees.Blazor.RichTextEditor.Samples/Spillgebees.Blazor.RichTextEditor.Samples.Shared/Pages/RichTextEditorExamplesPageContent.razor
@@ -27,6 +27,8 @@
                 <IsTouchedEventCallbackExample />
 
                 <IsEditorEnabledRichTextEditorExample />
+
+                <NoToolbarExample />
             </div>
 
             <a href="other"

--- a/src/Spillgebees.Blazor.RichTextEditor/Components/BaseRichTextEditor.razor.cs
+++ b/src/Spillgebees.Blazor.RichTextEditor/Components/BaseRichTextEditor.razor.cs
@@ -166,7 +166,9 @@ public abstract partial class BaseRichTextEditor : ComponentBase, IAsyncDisposab
         .AddClass("rich-text-editor-toolbar-container-bottom", ToolbarOptions.ToolbarPosition is ToolbarPosition.Bottom)
         .AddClass(ToolbarOptions.ToolbarContainerClass)
         .AddClass(ToolbarOptions.ToolbarContainerDisabledClass, IsEditorEnabled is false && ToolbarOptions.ToolbarDisabledBehavior is ToolbarDisabledBehavior.Disabled)
-        .AddClass(ToolbarOptions.ToolbarContainerHiddenClass, IsEditorEnabled is false && ToolbarOptions.ToolbarDisabledBehavior is ToolbarDisabledBehavior.Hidden)
+        .AddClass(ToolbarOptions.ToolbarContainerHiddenClass, IsEditorEnabled is false
+                                                              && ToolbarOptions.ToolbarDisabledBehavior is ToolbarDisabledBehavior.Hidden
+                                                              || ToolbarOptions.HideToolbar)
         .Build();
 
     protected ElementReference QuillReference;

--- a/src/Spillgebees.Blazor.RichTextEditor/Components/Toolbar/ToolbarOptions.cs
+++ b/src/Spillgebees.Blazor.RichTextEditor/Components/Toolbar/ToolbarOptions.cs
@@ -23,7 +23,8 @@ public record ToolbarOptions(
     string ToolbarContainerClass = "",
     ToolbarDisabledBehavior ToolbarDisabledBehavior = ToolbarDisabledBehavior.Disabled,
     string ToolbarContainerDisabledClass = "rich-text-editor-toolbar-container-disabled",
-    string ToolbarContainerHiddenClass = "rich-text-editor-toolbar-container-hidden")
+    string ToolbarContainerHiddenClass = "rich-text-editor-toolbar-container-hidden",
+    bool HideToolbar = false)
 {
     private static readonly List<string> _defaultFonts =
     [
@@ -64,4 +65,26 @@ public record ToolbarOptions(
             ShowMathControls = true,
             ShowCleanFormattingControls = true,
         };
-};
+
+    public static ToolbarOptions None
+        => new()
+        {
+            ShowFontControls = false,
+            ShowSizeControls = false,
+            ShowStyleControls = false,
+            ShowColorControls = false,
+            ShowHeaderControls = false,
+            ShowQuotationControls = false,
+            ShowCodeBlockControls = false,
+            ShowListControls = false,
+            ShowIndentationControls = false,
+            ShowAlignmentControls = false,
+            ShowDirectionControls = false,
+            ShowHypertextLinkControls = false,
+            ShowInsertImageControls = false,
+            ShowEmbedVideoControls = false,
+            ShowMathControls = false,
+            ShowCleanFormattingControls = false,
+            HideToolbar = true
+        };
+}


### PR DESCRIPTION
Resolves #52 by adding a `ToolbarOptions.HideToolbar` flag which applies the same "hidden" logic to the toolbar that is already in place for `ToolbarOptions.ToolbarDisabledBehavior.Hidden`.