### PR TITLE
:green_heart: fix CI path filters to trigger on dependency changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,8 +25,12 @@ jobs:
           filters: |
             changed:
               - 'src/Spillgebees.Blazor.RichTextEditor/**'
+              - 'src/Spillgebees.Blazor.RichTextEditor.Assets/**'
               - 'src/Spillgebees.Blazor.RichTextEditor.Samples/**'
               - 'src/Spillgebees.Blazor.RichTextEditor.Tests/**'
+              - 'src/Directory.Packages.props'
+              - 'src/General.targets'
+              - 'src/global.json'
 
   build-and-test:
     name: build-and-test

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           filters: |
             changed:
+              - 'src/Spillgebees.Blazor.RichTextEditor.Assets/**'
               - 'src/Spillgebees.Blazor.RichTextEditor.JS.Tests/**'
 
   node-test:


### PR DESCRIPTION
Adds missing paths to dorny/paths-filter so Renovate PRs for npm dependencies, NuGet package versions, build config, and SDK version changes properly trigger CI builds instead of being silently skipped.