### PR TITLE
🔒 fix zizmor findings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: 🔎 checking for changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: 📦 setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish nuget package
 
+permissions: {}
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Fixes the medium-severity findings from the org-wide [zizmor](https://docs.zizmor.sh/) baseline run.

## Fixes by audit rule

### [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) (2 medium)
Checkout steps persisted the `GITHUB_TOKEN` in the workspace by default, where later steps (or uploaded artifacts) could leak it.
- `.github/workflows/build-and-test.yml`: added `persist-credentials: false` to the checkout step in the `changes` job.
- `.github/workflows/build-test-publish.yml`: added `persist-credentials: false` to the checkout step. The gh-pages deploy steps are unaffected since `peaceiris/actions-gh-pages` receives `github_token` explicitly.

### [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions) (2 medium)
`publish.yml` had no `permissions:` block, so all jobs ran with the default (broad) token permissions.
- Added top-level `permissions: {}`. The `build-and-test` job keeps its explicit `contents: write` grant (needed for the gh-pages deploy); the `publish` job inherits no permissions — it only downloads a same-run artifact and pushes to NuGet via `NUGET_API_KEY`, neither of which needs `GITHUB_TOKEN` permissions.

This matches the convention in the sibling repo Blazor.Map (top-level `permissions: {}` with explicit job-level grants).

## zizmor results

| | informational | low | medium | high |
|---|---|---|---|---|
| before | 1 | 0 | 4 | 0 |
| after | 1 | 0 | 0 | 0 |

The remaining informational finding is [`use-trusted-publishing`](https://docs.zizmor.sh/audits/#use-trusted-publishing) on the NuGet push step — intentionally deferred, as trusted publishing migration is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configurations for CI/CD workflows, including credential isolation and permission restrictions to strengthen build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->