### PR TITLE
🐛  fix tooltips rendering underneath controls

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.302",
     "rollForward": "feature"
   },
   "test": {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,20 +1,20 @@
 <Project>
   <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-
-    <AspNetCoreVersion>10.0.9</AspNetCoreVersion>
+    <AspNetCoreVersion>10.0.10</AspNetCoreVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.5.1" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="AngleSharp" Version="1.6.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="BlazorComponentUtilities" Version="1.8.0" />
-    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="bunit" Version="2.8.6" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="TUnit.Core" Version="1.58.0" />
-    <PackageVersion Include="TUnit.Engine" Version="1.58.0" />
+    <PackageVersion Include="TUnit.Core" Version="1.62.0" />
+    <PackageVersion Include="TUnit.Engine" Version="1.62.0" />
   </ItemGroup>
 </Project>

--- a/src/Spillgebees.Blazor.RichTextEditor.Assets/src/styles.css
+++ b/src/Spillgebees.Blazor.RichTextEditor.Assets/src/styles.css
@@ -16,6 +16,11 @@
   border-top: none;
 }
 
+/* Keep Quill's tooltip above toolbar controls when the toolbar is rendered below the editor. */
+.ql-snow .ql-tooltip {
+  z-index: 1;
+}
+
 .ql-toolbar.ql-snow.rich-text-editor-toolbar-container-hidden
   + .ql-container.ql-snow.rich-text-editor-editor-container {
   border-top: 1px solid #ccc;


### PR DESCRIPTION
Closes: #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Quill editor tooltips could appear behind toolbar controls when the toolbar is positioned below the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->